### PR TITLE
fix(typescript):  MongooseModels types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as mongoose from 'mongoose';
 declare module 'egg' {
 
   type MongooseModels = {
-    [key: string]: mongoose.Model<any>
+    [key: string]: mongoose.Model
   };
 
   type MongooseSingleton = {


### PR DESCRIPTION
After add a mongoose to Schema,  ctx.model can't read this plugin's extends function or property.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change
type MongooseModels = {
    [key: string]: mongoose.Model<any>
  };

changeTo

type MongooseModels = {
    [key: string]: mongoose.Model
  };
